### PR TITLE
fix: overflowed and uncenter header masthead

### DIFF
--- a/files/styles/homepage.css
+++ b/files/styles/homepage.css
@@ -166,3 +166,30 @@ p {
 i {
   color: yellow;
 }
+
+/* Header */
+
+.header-masthead {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  align-content: center;
+  max-width: 32rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.header-masthead > img {
+  border: 4px solid #4caf50;
+  border-radius: 100%;
+  max-width: 150px;
+  max-height: 150px;
+  left: 30%;
+}
+
+.header-masthead > span {
+  margin-left: 1rem;
+  font-family: "Londrina Shadow";
+  font-size: 370%;
+  color: #00aeff;
+}

--- a/files/styles/homepage.css
+++ b/files/styles/homepage.css
@@ -193,3 +193,7 @@ i {
   font-size: 370%;
   color: #00aeff;
 }
+
+header > hr {
+  margin-bottom: 2rem;
+}

--- a/index.html
+++ b/index.html
@@ -23,8 +23,11 @@
     <title>DuckMasterAl's Website</title>
   </head>
   <header>
-    <div id="h1div"><img src="files/avatar.gif" alt="DuckMasterAl's Avatar" class="avatar"><span id="h1">DuckMasterAl</span></div>
-    <h2 class="blue">Hi, I'm DuckMasterAl! I develop discord bots, like <a class="blue" href="https://quacky.js.org">Quacky Bot</a>, and love Ducks 🦆</h2><hr/><br/>
+    <div class="header-masthead">
+      <img style="max-width: 150px;" src="files/avatar.gif" alt="DuckMasterAl's Avatar">
+      <span>DuckMasterAl</span>
+    </div>
+    <h2>Hi, I'm DuckMasterAl! I develop discord bots, like <a href="https://quacky.js.org">Quacky Bot</a>, and love Ducks 🦆</h2><hr/>
   </header>
   <body onload="js_Load()">
     <script language="javascript">

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       <img style="max-width: 150px;" src="files/avatar.gif" alt="DuckMasterAl's Avatar">
       <span>DuckMasterAl</span>
     </div>
-    <h2>Hi, I'm DuckMasterAl! I develop discord bots, like <a href="https://quacky.js.org">Quacky Bot</a>, and love Ducks 🦆</h2><hr/>
+    <h2 class="blue">Hi, I'm DuckMasterAl! I develop discord bots, like <a href="https://quacky.js.org">Quacky Bot</a>, and love Ducks 🦆</h2><hr/>
   </header>
   <body onload="js_Load()">
     <script language="javascript">

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       <img style="max-width: 150px;" src="files/avatar.gif" alt="DuckMasterAl's Avatar">
       <span>DuckMasterAl</span>
     </div>
-    <h2 class="blue">Hi, I'm DuckMasterAl! I develop discord bots, like <a href="https://quacky.js.org">Quacky Bot</a>, and love Ducks 🦆</h2><hr/>
+    <h2 class="blue">Hi, I'm DuckMasterAl! I develop discord bots, like <a class="blue" href="https://quacky.js.org">Quacky Bot</a>, and love Ducks 🦆</h2><hr/>
   </header>
   <body onload="js_Load()">
     <script language="javascript">


### PR DESCRIPTION
This PR fixes the header's masthead where it is not centered properly and overflows on small screen

Preview after the PR
![Image preview](https://user-images.githubusercontent.com/2129163/91275882-efb08100-e7aa-11ea-8916-08a632f00d5d.png)

Resolves #10 
Signed-off-by: Christopher Angelo <angelo@angeloanan.xyz>