### PR TITLE
fix: 404 page and css

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <link href="https://fonts.googleapis.com/css2?family=Happy+Monkey&family=Londrina+Shadow&family=Montserrat&family=Baloo+Tamma+2&family=Comfortaa&display=swap" rel="stylesheet">
-    <link href="files/styles/subpage.css" rel="stylesheet">
-    <link rel="icon" href="files/support.ico">
+    <link href="/files/styles/subpage.css" rel="stylesheet">
+    <link rel="icon" href="/files/support.ico">
     <meta charset="UTF-8">
     <meta name="og:image" itemprop="image" content="https://duck.js.org/files/support.webp">
     <meta name="description" content="This page doesn't exist!">
@@ -20,14 +20,14 @@
     }
     function changeImage() {
       var image = document.getElementById("support404");
-      if (image.src.includes('files/support')){
-        var mp3Source = '<source src="' + 'files/ping' + '.mp3" type="audio/mpeg">';
-        var oggSource = '<source src="' + 'files/ping' + '.ogg" type="audio/ogg">';
-        var embedSource = '<embed hidden="true" autostart="true" loop="false" src="' + 'files/ping' +'.mp3">';
+      if (image.src.includes('https://duck.js.org/files/support.webp')){
+        var mp3Source = '<source src="' + '/files/ping' + '.mp3" type="audio/mpeg">';
+        var oggSource = '<source src="' + '/files/ping' + '.ogg" type="audio/ogg">';
+        var embedSource = '<embed hidden="true" autostart="true" loop="false" src="' + '/files/ping' +'.mp3">';
         image.innerHTML='<audio autoplay="autoplay">' + mp3Source + oggSource + embedSource + '</audio>'
-        image.src = "files/angrysupport.webp";
+        image.src = "https://duck.js.org/files/angrysupport.webp";
       } else if (image.src.includes("files/angrysupport.webp")) {
-        image.src = "files/support.webp";
+        image.src = "https://duck.js.org/files/support.webp";
       }
     }
     </script>

--- a/404.html
+++ b/404.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <link href="https://fonts.googleapis.com/css2?family=Happy+Monkey&family=Londrina+Shadow&family=Montserrat&family=Baloo+Tamma+2&family=Comfortaa&display=swap" rel="stylesheet">
-    <link href="/files/styles/subpage.css" rel="stylesheet">
-    <link rel="icon" href="/files/support.ico">
+    <link href="files/styles/subpage.css" rel="stylesheet">
+    <link rel="icon" href="files/support.ico">
     <meta charset="UTF-8">
     <meta name="og:image" itemprop="image" content="https://duck.js.org/files/support.webp">
     <meta name="description" content="This page doesn't exist!">
@@ -26,19 +26,16 @@
       }
       function changeImage() {
         var image = document.getElementById("support404");
-        if (image.src == 'https://duck.js.org/files/support.webp')
-        {
+      if (image.src.includes('files/support')){
           var mp3Source = '<source src="' + 'files/ping' + '.mp3" type="audio/mpeg">';
           var oggSource = '<source src="' + 'files/ping' + '.ogg" type="audio/ogg">';
           var embedSource = '<embed hidden="true" autostart="true" loop="false" src="' + 'files/ping' +'.mp3">';
           image.innerHTML='<audio autoplay="autoplay">' + mp3Source + oggSource + embedSource + '</audio>'
-          image.src = "https://duck.js.org/files/angrysupport.webp";
+        image.src = "files/angrysupport.webp";
+      } else if (image.src.includes("files/angrysupport.webp")) {
+        image.src = "files/support.webp";
         }
-        else if (image.src == "https://duck.js.org/files/angrysupport.webp")
-        {
-          image.src = "https://duck.js.org/files/support.webp";
         }
-      }
       </script>
     <p>Hello! I'm  from Duck Support. The issue is that this page doesn't exist!</p>
     <p>It either has been moved to a different link or removed from the site.</p>

--- a/404.html
+++ b/404.html
@@ -13,13 +13,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>404 | DuckMasterAl</title>
   </head>
-    <h1>404 Duck Not Found!</h1>
-    <h3 class="center">Initating a Duck Support Team...</h3>
-    <a onclick="changeImage()"><img src="/files/support.webp" width="200" height="200" id="support404" alt="Bongo Duck Support Image"></a>
-    <hr/><br/>
-  </header>
   <body onload="js_Load()">
-    <header>
       <script language="javascript">
       function js_Load() {
         document.body.style.visibility='visible';
@@ -37,7 +31,13 @@
         }
         }
       </script>
-    <p>Hello! I'm  from Duck Support. The issue is that this page doesn't exist!</p>
+    <header>
+      <h1>404 Duck Not Found!</h1>
+      <h3 class="center">Initating a Duck Support Team...</h3>
+      <a onclick="changeImage()"><img src="files/support.webp" width="200" height="200" id="support404" alt="Bongo Duck Support Image"></a>
+      <hr/><br/>
+    </header>
+    <p>Hello! I'm from Duck Support. The issue is that this page doesn't exist!</p>
     <p>It either has been moved to a different link or removed from the site.</p>
     <p>If you think this page should exist <a class="blue" href="https://github.com/DuckMasterAl/DuckMasterAl.github.io/issues/new/choose">Fill out an Issue Here!</a> Thanks 🦆</p>
     <p>You can now <a class="button" href="/index.html">Go back to the Homepage</a> or <a class="button" onclick="window.history.back();">Go to the last page you were on</a></p>

--- a/404.html
+++ b/404.html
@@ -36,6 +36,7 @@
         <div style="flex-shrink: 3;">
           <img src="files/support.webp" id="support404" alt="Bongo Duck Support Image" onclick="changeImage()">
         </div>
+        <div style="margin: 1em;"></div>
         <div style="flex-shrink: 0;">
           <h1>404 Duck Not Found!</h1>
           <h3>Initating a Duck Support Team...</h3>

--- a/404.html
+++ b/404.html
@@ -34,7 +34,7 @@
     <header>
       <div class="header-masthead">
         <div style="flex-shrink: 3;">
-          <img src="files/support.webp" id="support404" alt="Bongo Duck Support Image" onclick="changeImage()">
+          <img src="/files/support.webp" id="support404" alt="Bongo Duck Support Image" onclick="changeImage()">
         </div>
         <div style="margin: 1em;"></div>
         <div style="flex-shrink: 0;">

--- a/404.html
+++ b/404.html
@@ -14,28 +14,34 @@
     <title>404 | DuckMasterAl</title>
   </head>
   <body onload="js_Load()">
-      <script language="javascript">
-      function js_Load() {
-        document.body.style.visibility='visible';
-      }
-      function changeImage() {
-        var image = document.getElementById("support404");
+    <script language="javascript">
+    function js_Load() {
+      document.body.style.visibility='visible';
+    }
+    function changeImage() {
+      var image = document.getElementById("support404");
       if (image.src.includes('files/support')){
-          var mp3Source = '<source src="' + 'files/ping' + '.mp3" type="audio/mpeg">';
-          var oggSource = '<source src="' + 'files/ping' + '.ogg" type="audio/ogg">';
-          var embedSource = '<embed hidden="true" autostart="true" loop="false" src="' + 'files/ping' +'.mp3">';
-          image.innerHTML='<audio autoplay="autoplay">' + mp3Source + oggSource + embedSource + '</audio>'
+        var mp3Source = '<source src="' + 'files/ping' + '.mp3" type="audio/mpeg">';
+        var oggSource = '<source src="' + 'files/ping' + '.ogg" type="audio/ogg">';
+        var embedSource = '<embed hidden="true" autostart="true" loop="false" src="' + 'files/ping' +'.mp3">';
+        image.innerHTML='<audio autoplay="autoplay">' + mp3Source + oggSource + embedSource + '</audio>'
         image.src = "files/angrysupport.webp";
       } else if (image.src.includes("files/angrysupport.webp")) {
         image.src = "files/support.webp";
-        }
-        }
-      </script>
+      }
+    }
+    </script>
     <header>
-      <h1>404 Duck Not Found!</h1>
-      <h3 class="center">Initating a Duck Support Team...</h3>
-      <a onclick="changeImage()"><img src="files/support.webp" width="200" height="200" id="support404" alt="Bongo Duck Support Image"></a>
-      <hr/><br/>
+      <div class="header-masthead">
+        <div style="flex-shrink: 3;">
+          <img src="files/support.webp" id="support404" alt="Bongo Duck Support Image" onclick="changeImage()">
+        </div>
+        <div style="flex-shrink: 0;">
+          <h1>404 Duck Not Found!</h1>
+          <h3>Initating a Duck Support Team...</h3>
+        </div>
+      </div>
+      <hr>
     </header>
     <p>Hello! I'm from Duck Support. The issue is that this page doesn't exist!</p>
     <p>It either has been moved to a different link or removed from the site.</p>

--- a/files/styles/subpage.css
+++ b/files/styles/subpage.css
@@ -82,13 +82,16 @@ h2 {
 }
 
 .bottom {
-  height: 20px;
+  left: 0%;
+  bottom: 0%;
   width: 100%;
+  height: 20px;
   background-color: #23272A;
   border-radius: 6px;
   text-align: center;
   color: white;
-  padding: 5px 5px;
+  padding-top: 5px;
+  padding-bottom: 5px;
   font-family: "Baloo Tamma 2";
 }
 

--- a/files/styles/subpage.css
+++ b/files/styles/subpage.css
@@ -116,7 +116,6 @@ p {
   max-height: 200px;
   width: 100%;
   height: auto;
-  margin-right: 2rem;
   border: 2px solid #4caf50;
   border-radius: 100%;
   transition-duration: 0.4s;
@@ -145,6 +144,6 @@ p {
 .header-masthead {
   justify-content: center;
   display: flex;
-  flex-direction: row;
+  flex-direction: row-reverse;
   align-items: center;
 }

--- a/files/styles/subpage.css
+++ b/files/styles/subpage.css
@@ -109,9 +109,11 @@ p {
 }
 
 #support404 {
-  position: absolute;
-  left: 990px;
-  top: 10px;
+  max-width: 200px;
+  max-height: 200px;
+  width: 100%;
+  height: auto;
+  margin-right: 2rem;
   border: 2px solid #4caf50;
   border-radius: 100%;
   transition-duration: 0.4s;
@@ -134,4 +136,12 @@ p {
   border: 2px solid orange;
   background-color: #4caf50;
   border-radius: 100%;
+}
+
+/* 404 Header */
+.header-masthead {
+  justify-content: center;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }


### PR DESCRIPTION
This PR adjusts the header of the 404 page so that its displayed correctly.   
This PR also resolves the horizontal overflow issue. The cause was the footer CSS not having needed property.

Preview after fix
![image](https://user-images.githubusercontent.com/2129163/91281550-6e5cec80-e7b2-11ea-9b93-7d1c0bd9e35f.png)

Resolves #10 